### PR TITLE
Fix Off by 1 error

### DIFF
--- a/src/nemo_spinup_forecast/forecast.py
+++ b/src/nemo_spinup_forecast/forecast.py
@@ -628,11 +628,11 @@ class Predictions:
             x_pred : ndarray
                 Prediction features.
         """
-        x_train = np.linspace(0, 1, train_len).reshape(-1, 1)
-        pas = x_train[1, 0] - x_train[0, 0]
+        x_train, pas = np.linspace(0, 1, train_len, retstep=True)
+        x_train = x_train.reshape(-1, 1)
         # x_pred = np.arange(0, (len(self) + steps) * pas, pas).reshape(-1, 1)
         # TODO: Check this len(self) + steps logic
-        x_pred = np.arange(1, 1 + steps * pas, pas).reshape(-1, 1)
+        x_pred = np.linspace(1 + pas, 1 + steps * pas, steps).reshape(-1, 1)
 
         y_train = self.data[self.var + "-" + str(n)].iloc[:train_len].to_numpy()
         mean, std = np.nanmean(y_train), np.nanstd(y_train)

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -230,13 +230,15 @@ def test_train_test_series_standard_case(setup_prediction_class):
     assert np.allclose(y_test.flatten(), raw_test)
 
     # x_train should be linspace
-    expected_x_train = np.linspace(0, 1, train_len).reshape(-1, 1)
+    expected_x_train, pas = np.linspace(0, 1, train_len, retstep=True)
+    expected_x_train = expected_x_train.reshape(-1, 1)
+
     assert np.allclose(x_train, expected_x_train)
 
     # x_pred should span entire series length + steps with uniform spacing
     pas = x_train[1, 0] - x_train[0, 0]  # time step size
     total_len = steps
-    expected_x_pred = np.arange(1, 1 + total_len * pas, pas).reshape(-1, 1)
+    expected_x_pred = np.linspace(1 + pas, 1 + steps * pas, steps).reshape(-1, 1)
     assert np.allclose(x_pred, expected_x_pred)
 
 


### PR DESCRIPTION
Within the `train_test_series` function there is an off by 1 when calculating `x_pred` due to floating point error

e.g
When number of steps predicted is 5

We use `x_pred `to predict the corresponding `y_values`

`x_pred = np.arange(1, 1 + steps * pas, pas)` produces an array of size 6
`x_pred = np.arange(1+pas, 1 + steps * pas, pas)` produces an array of size 4

The behaviour we want is that we get an array of size 5. Numpy [docs](https://numpy.org/doc/stable/user/how-to-partition.html) suggest using linspace to avoid issues like this. I think we can simplify the x_train and x_pred logic.

To fix this we can use:
`np.linspace(1 + pas, 1 + steps * pas, steps)`