### PR TITLE
Helpful error message if the data path is wrong

### DIFF
--- a/src/nemo_spinup_forecast/cli.py
+++ b/src/nemo_spinup_forecast/cli.py
@@ -74,6 +74,19 @@ def main(argv=None) -> int:
 
     args = parser.parse_args(argv)
 
+    # Validate that the data path exists
+    data_path = Path(args.path).expanduser().resolve()
+    if not data_path.exists():
+        parser.error(
+            f"Data path does not exist: {args.path}\n"
+            "  Please check the path and try again.\n"
+        )
+    if not data_path.is_dir():
+        parser.error(
+            f"Data path is not a directory: {args.path}\n"
+            "  Please provide a path to the directory containing the simulation files."
+        )
+
     # Load config file of techniques
     if args.techniques_config:
         techniques_config_path = Path(args.techniques_config).expanduser().resolve()


### PR DESCRIPTION
If the user provides a non-existent directory for --path (or a file) they get a pretty inscrutable runtime error, e.g.
```
> python -m nemo_spinup_forecast --ye True --start 20 --end 50 --comp 1 --steps 30 --path tests/data/nonexistent
...
Preparing ssh...
Using normal PCA
Traceback (most recent call last):
  ...
  File ".../forecast.py", line 185, in get_attributes
    self.files[-1], decode_times=False, chunks={"time": 200, "x": 120}
IndexError: list index out of range
```
This PR checks earlier on in the cli.py whether the path is valid then gives a message e.g.:
```
> python -m nemo_spinup_forecast --ye True --start 20 --end 50 --comp 1 --steps 30 --path tests/data/nonexistent
usage: __main__.py [-h] --path PATH [--ye YE] --start START --end END --steps STEPS [--comp COMP] [--ocean-terms OCEAN_TERMS]
                   [--techniques-config TECHNIQUES_CONFIG]
__main__.py: error: Data path does not exist: tests/data/nonexistent
  Please check the path and try again.
```